### PR TITLE
Redesing v2

### DIFF
--- a/android/src/main/java/com/wwimmo/imageeditor/ImageEditor.java
+++ b/android/src/main/java/com/wwimmo/imageeditor/ImageEditor.java
@@ -24,6 +24,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Base64;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
@@ -955,10 +956,11 @@ public class ImageEditor extends View {
 
     protected void startMeasurementToolEntity(String imageShapeAsset) {
         Layer layer = new Layer();
+        DisplayMetrics dm = mContext.getResources().getDisplayMetrics();
         if (mDrawingCanvas.getWidth() > mSketchCanvas.getWidth() || mDrawingCanvas.getHeight() > mSketchCanvas.getHeight()) {
-            measurementEntity = new MeasureToolEntity(layer, mDrawingCanvas.getWidth(), mDrawingCanvas.getHeight(), imageShapeAsset);
+            measurementEntity = new MeasureToolEntity(layer, mDrawingCanvas.getWidth(), mDrawingCanvas.getHeight(), imageShapeAsset, dm);
         } else {
-            measurementEntity = new MeasureToolEntity(layer, mSketchCanvas.getWidth(), mSketchCanvas.getHeight(), imageShapeAsset);
+            measurementEntity = new MeasureToolEntity(layer, mSketchCanvas.getWidth(), mSketchCanvas.getHeight(), imageShapeAsset, dm);
         }
         if (imageShapeAsset != null) {
             getBitmap(prepareUri(imageShapeAsset), 0, 0, new BaseBitmapDataSubscriber() {
@@ -981,6 +983,8 @@ public class ImageEditor extends View {
             });
         }
         addEntityAndPosition(measurementEntity);
+        measurementEntity.addPoint(measurementEntity.getWidth() * 0.35f, measurementEntity.getHeight() /2);
+        measurementEntity.addPoint(measurementEntity.getWidth() * 0.65f, measurementEntity.getHeight() /2);
     }
 
     protected void addSquareEntity(int width) {
@@ -1455,7 +1459,12 @@ public class ImageEditor extends View {
             // Left item selected
             super.onMoveEnd(detector);
             if (mSelectedEntity instanceof MeasureToolEntity) {
-                ((MeasureToolEntity) mSelectedEntity).setFocused(false);
+                MeasureToolEntity entity = (MeasureToolEntity) mSelectedEntity;
+                if (!shouldUpdateOnEnd && entity.isTextStep()) {
+                    onDrawingStateChanged();
+                }else {
+                    ((MeasureToolEntity) mSelectedEntity).setFocused(false);
+                }
             }
             if (shouldUpdateOnEnd) {
                 if (isInProgress) {

--- a/android/src/main/java/com/wwimmo/imageeditor/utils/entities/MeasureToolEntity.java
+++ b/android/src/main/java/com/wwimmo/imageeditor/utils/entities/MeasureToolEntity.java
@@ -139,7 +139,7 @@ public class MeasureToolEntity extends MotionEntity {
         this.mCanvas.save();
         this.mCanvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);
         float savedStrokeWidth = mPaint.getStrokeWidth();
-        float outerRadiusFull = outerRadius + innerRadius + strokeWidth;
+        float outerRadiusFull = outerRadius + innerRadius + strokeWidth / 2f;
 
         if (currentPoints.size() > 0) {
             for (int i = 0; i < currentPoints.size(); i++) {
@@ -184,7 +184,7 @@ public class MeasureToolEntity extends MotionEntity {
             mPaint.setStrokeWidth(savedStrokeWidth);
         }
 
-        if (currentPoints.size() > 1) {
+        if (currentPoints.size() > 1 && this.endpointBitmap != null) {
             boolean firstVisited = this.pointsVisited.get(0);
             boolean secondVisited = this.pointsVisited.get(1);
             if (!secondVisited && selectedPoint != this.currentPoints.get(1)) {
@@ -250,14 +250,15 @@ public class MeasureToolEntity extends MotionEntity {
         int centerY = (int) drawPoint.y;
         // Create a circular path
         Path path = new Path();
-        path.addCircle(centerX, centerY, lensSize / 2, Path.Direction.CW);
+        float halfLensSize = lensSize / 2f;
+        path.addCircle(centerX, centerY, halfLensSize, Path.Direction.CW);
         // Clip the canvas to the circular path
         mCanvas.clipPath(path);
         RectF drawingRect = new RectF(
-                centerX - lensSize / 2,
-                centerY - lensSize / 2,
-                centerX + lensSize / 2,
-                centerY + lensSize / 2
+                centerX - halfLensSize,
+                centerY - halfLensSize,
+                centerX + halfLensSize,
+                centerY + halfLensSize
         );
         mCanvas.drawBitmap(mZoomBitmap, null, drawingRect, null);
         mCanvas.restore();
@@ -265,10 +266,10 @@ public class MeasureToolEntity extends MotionEntity {
 
         this.mPaint.setStyle(Paint.Style.STROKE);
         this.mPaint.setStrokeWidth(strokeWidth);
-        this.mCanvas.drawCircle(centerX, centerY, lensSize / 2, this.mPaint);
+        this.mCanvas.drawCircle(centerX, centerY, halfLensSize, this.mPaint);
 
         this.mPaint.setStyle(Paint.Style.FILL);
-        this.mCanvas.drawCircle(centerX, centerY, strokeWidth, this.mPaint);
+        this.mCanvas.drawCircle(centerX, centerY, strokeWidth / 2f, this.mPaint);
     }
 
 

--- a/android/src/main/java/com/wwimmo/imageeditor/utils/entities/MeasureToolEntity.java
+++ b/android/src/main/java/com/wwimmo/imageeditor/utils/entities/MeasureToolEntity.java
@@ -591,7 +591,7 @@ public class MeasureToolEntity extends MotionEntity {
                 displayMetrics);
         mTextPaint.setStyle(Paint.Style.FILL);
         mTextPaint.setTextSize(realFontSize);
-        mTextPaint.setColor(Color.WHITE);
+        mTextPaint.setColor(Color.BLACK);
         mScaledDensity = displayMetrics.scaledDensity;
     }
 

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1197,9 +1197,9 @@
         } else {
             if (self.measurementEntity != nil && ![self.measurementEntity isPointInEntity:tapLocation]){
                 if ( [self.measurementEntity getDrawingStep] < 2) {
-                    // add new point
+                    // add new point if posible, return true if added or text is not defined
                     _isMeasurementInProgress = [_measurementEntity addPoint:tapLocation];
-                    _shouldHandleEndMove = true;
+                    _shouldHandleEndMove = false;
                     // Update UI
                     [self.measurementEntity setNeedsDisplay];
                 }
@@ -1216,11 +1216,11 @@
 
         if (state == UIGestureRecognizerStateCancelled || state == UIGestureRecognizerStateEnded) {
             if ([self.selectedEntity class] == [MeasurementEntity class]) {
-                if (!_shouldHandleEndMove && [_measurementEntity isTextStep]) {
-                    [self onDrawingStateChanged];
-                } else {
-                    [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
-                }
+                 if (!_shouldHandleEndMove && [_measurementEntity isTextStep]) {
+                     [self onDrawingStateChanged];
+                 } else {
+                     [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
+                 }
             }
             if (_shouldHandleEndMove) {
                 if (!_isMeasurementInProgress) {

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -967,6 +967,8 @@
                               entityStrokeColor:self.entityStrokeColor];
 
     _measurementEntity = entity;
+    [_measurementEntity addPoint:CGPointMake(centerX - 50, centerY)];
+    [_measurementEntity addPoint:CGPointMake(centerX + 50, centerY)];
     [self handleLoadImage:imageShapeAsset];
     [self onAddShape:entity];
 }
@@ -1193,12 +1195,14 @@
             // select shape
             [self updateSelectionOnTapWithLocationPoint:tapLocation];
         } else {
-            if (self.measurementEntity != nil && ![self.measurementEntity isPointInEntity:tapLocation] && [self.measurementEntity getDrawingStep] < 2) {
-                // add new point
-                _isMeasurementInProgress = [_measurementEntity addPoint:tapLocation];
-                _shouldHandleEndMove = true;
-                // Update UI
-                [self.measurementEntity setNeedsDisplay];
+            if (self.measurementEntity != nil && ![self.measurementEntity isPointInEntity:tapLocation]){
+                if ( [self.measurementEntity getDrawingStep] < 2) {
+                    // add new point
+                    _isMeasurementInProgress = [_measurementEntity addPoint:tapLocation];
+                    _shouldHandleEndMove = true;
+                    // Update UI
+                    [self.measurementEntity setNeedsDisplay];
+                }
             }
         }
     }
@@ -1212,7 +1216,11 @@
 
         if (state == UIGestureRecognizerStateCancelled || state == UIGestureRecognizerStateEnded) {
             if ([self.selectedEntity class] == [MeasurementEntity class]) {
-                [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
+                if (!_shouldHandleEndMove && [_measurementEntity isTextStep]) {
+                    [self onDrawingStateChanged];
+                } else {
+                    [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
+                }
             }
             if (_shouldHandleEndMove) {
                 if (!_isMeasurementInProgress) {

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -110,6 +110,15 @@
     return TRUE;
 }
 
+- (BOOL)hasMeasurements {
+    for (MotionEntity *entity in self.motionEntities) {
+        if ([entity class] == [MeasurementEntity class]){
+            return YES;
+        }
+    }
+    return NO;
+}
+
 - (void)drawRect:(CGRect)rect {
     CGContextRef context = UIGraphicsGetCurrentContext();
 
@@ -146,6 +155,12 @@
 
     if (_frozenImage) {
         CGContextDrawImage(context, bounds, _frozenImage);
+        if ([self hasMeasurements]){
+            // draw dark overlay
+            CGContextSetFillColorWithColor(context, [[UIColor.blackColor colorWithAlphaComponent:0.3f] CGColor]);
+            CGContextFillRect(context, bounds);
+            CGContextSetFillColorWithColor(context, [UIColor.clearColor CGColor]);
+        }
     }
 
     if (_translucentFrozenImage && _currentPath.isTranslucent) {
@@ -451,6 +466,13 @@
 
         CGContextDrawImage(context, targetRect, _frozenImage);
         CGContextDrawImage(context, targetRect, _translucentFrozenImage);
+
+        if ([self hasMeasurements]){
+            // draw dark overlay
+            CGContextSetFillColorWithColor(context, [[UIColor.blackColor colorWithAlphaComponent:0.3f] CGColor]);
+            CGContextFillRect(context, targetRect);
+            CGContextSetFillColorWithColor(context, [UIColor.clearColor CGColor]);
+        }
 
         if (includeText) {
             for (BackgroundText *text in _arrTextOnSketch) {
@@ -1218,9 +1240,9 @@
             if ([self.selectedEntity class] == [MeasurementEntity class]) {
                  if (!_shouldHandleEndMove && [_measurementEntity isTextStep]) {
                      [self onDrawingStateChanged];
-                 } else {
-                     [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
                  }
+                 [((MeasurementEntity *)self.selectedEntity) setLocalFocused:false];
+
             }
             if (_shouldHandleEndMove) {
                 if (!_isMeasurementInProgress) {

--- a/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
+++ b/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
@@ -22,8 +22,8 @@ int MAX_POINTS_COUNT = 2;
 int DEFAULT_SELECTED_POSITION = -1;
 int TEXT_PADDING = 24;
 int TEXT_BOX_SIZE = 48;
-float pointSize = 10;
-float touchPointSize = 50;
+float pointSize = 12;
+float touchPointSize = 37;
 int selectedPosition;
 
 int LENS_WIDTH = 72;
@@ -142,25 +142,22 @@ NSTimer *timer;
             if (pointSelect == TRUE) {
                 CGPoint point = p;
                 // Draw selection indicator
-                float andgeInRadians = (25 * M_PI)/ 180;
-                CGContextSetLineWidth(contextRef, 4);
-                CGContextSetStrokeColorWithColor(contextRef, [self.entityStrokeColor CGColor]);
-                CGContextAddArc(contextRef, point.x  , point.y, touchPointSize , -M_PI + andgeInRadians, -andgeInRadians, 0);
+                CGContextSetLineWidth(contextRef, 8);
+                CGContextSetStrokeColorWithColor(contextRef, [[self.entityStrokeColor colorWithAlphaComponent:0.5f] CGColor]);
+                CGContextAddArc(contextRef, point.x  , point.y, touchPointSize , 0, 2*M_PI, 0);
                 CGContextStrokePath(contextRef);
-                CGContextAddArc(contextRef, point.x  , point.y, touchPointSize , andgeInRadians, M_PI - andgeInRadians, 0);
-                CGContextStrokePath(contextRef);
-
-                // Restore
-                CGContextSetLineWidth(contextRef, 2);
             }else if ([points count] > 1) {
                 // Pulsing indicator
                 // Calculate the pulsing circle's size
-                CGFloat circleRadius = 5 + 11 * pulseScale; // Base radius 10 and changable till 32
-                CGRect circleRect = [self buildRect:p withSize:circleRadius*2];
-                // Draw the circle
-                CGContextSetFillColorWithColor(contextRef, [[self.entityStrokeColor colorWithAlphaComponent:0.5f] CGColor]);
-                CGContextFillEllipseInRect(contextRef, circleRect);
+                CGFloat arcWidth =  8 * pulseScale;
+                CGContextSetLineWidth(contextRef, arcWidth);
+                CGContextSetStrokeColorWithColor(contextRef, [[self.entityStrokeColor colorWithAlphaComponent:0.5f] CGColor]);
+                CGContextAddArc(contextRef, p.x  , p.y, 14 , 0, 2 * M_PI, 0);
+                CGContextStrokePath(contextRef);
             }
+            // Restore
+            CGContextSetLineWidth(contextRef, 2);
+            CGContextSetStrokeColorWithColor(contextRef, [self.entityStrokeColor CGColor]);
 
             bool hasText = [self text] != nil;
             // draw text
@@ -397,7 +394,7 @@ void drawCircularImageInContext(CGContextRef context, CGImageRef image, CGRect r
 }
 
 - (void)drawConnection:(CGContextRef)contextRef withStartPoint:(CGPoint)startPoint withEndPoint:(CGPoint)endPoint withOffsetEnable:(bool)hasOffset {
-    CGContextSetLineWidth(contextRef, 2);
+    CGContextSetLineWidth(contextRef, 4);
     CGContextBeginPath(contextRef);
     CGPoint newStart = startPoint;
     CGPoint newEnd = endPoint;
@@ -413,17 +410,6 @@ void drawCircularImageInContext(CGContextRef context, CGImageRef image, CGRect r
         newEnd = [self getOuterRadiusPoint:endPoint withEndPoint:startPoint withRadius:radius];
     }
 
-    // Semi transparent line
-    UIColor* backgroundLineColor = [[UIColor darkGrayColor] colorWithAlphaComponent:0.5f];
-    CGContextSetStrokeColorWithColor(contextRef, [backgroundLineColor CGColor]);
-    CGContextMoveToPoint(contextRef, newStart.x, newStart.y);
-    CGContextAddLineToPoint(contextRef, newEnd.x, newEnd.y);
-    CGContextStrokePath(contextRef);
-
-    // Dashed line
-    float dashPhase = 0.0;
-    CGFloat dash[] = {4.0, 4.0};
-    CGContextSetLineDash(contextRef, dashPhase, dash, 2);
     CGContextSetStrokeColorWithColor(contextRef, [self.entityStrokeColor CGColor]);
     CGContextMoveToPoint(contextRef, newStart.x, newStart.y);
     CGContextAddLineToPoint(contextRef, newEnd.x, newEnd.y);

--- a/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
+++ b/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
@@ -177,7 +177,7 @@ NSTimer *timer;
         }
 
         // Draw indicator for not touched toints, one at a time
-        if ([pointsVisited count] > 1) {
+        if ([pointsVisited count] > 1 && endpointImage != nil) {
             bool visitedFirst = [[pointsVisited objectAtIndex:0] boolValue];
             bool visitedSecond = [[pointsVisited objectAtIndex:1] boolValue];
             if (!visitedSecond && selectedPosition != 1) {

--- a/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
+++ b/ios/RNImageEditor/RNImageEditor/entities/MeasurementEntity.m
@@ -82,7 +82,7 @@ NSTimer *timer;
 }
 
 - (BOOL)isCurrentPointsInRect:(CGRect)rect {
-    float touchArea = [self getTouchRadius];
+    float touchArea = 2 * [self getTouchRadius];
     for (int i=0; i < [points count]; i++) {
         NSValue *val = [points objectAtIndex:i];
         CGPoint p = [val CGPointValue];
@@ -293,7 +293,7 @@ void drawCircularImageInContext(CGContextRef context, CGImageRef image, CGRect r
 
 - (BOOL)isPointInEntity:(CGPoint)point {
     selectedPosition = DEFAULT_SELECTED_POSITION;
-    float touchArea = [self getTouchRadius];
+    float touchArea = 2 * [self getTouchRadius];
     for (int i=0; i < [points count]; i++) {
         NSValue *val = [points objectAtIndex:i];
         CGPoint p = [val CGPointValue];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/hoverinc/react-native-sketch-image"
     },
-    "version": "0.8.43",
+    "version": "0.8.44",
     "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
     "author": "Terry Lin, Thomas Steinbrüchel",
     "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/hoverinc/react-native-sketch-image"
     },
-    "version": "0.8.42",
+    "version": "0.8.43",
     "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
     "author": "Terry Lin, Thomas Steinbrüchel",
     "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/hoverinc/react-native-sketch-image"
     },
-    "version": "0.8.44",
+    "version": "0.8.45",
     "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
     "author": "Terry Lin, Thomas Steinbrüchel",
     "main": "index.js",


### PR DESCRIPTION
New design of Measurement tool

1. Make text black in RM 
2. IF editor has RM tool added dark overlay
3. Currently we add two points right after the RM entity and it's a base step for this type 
4. Android : Add recalculation  px -> dp; before were pixel and sizes were different. So all values for RM now in dp and converting to px with `Utility.convertDpToPx` because canvas use px values
5. Move text to the center between touch points
6. Zoom lens now circle and take place like text before (Corners of the image)
7. isTextStep now return `true` when user moved both points
8. Not used but supported : endpointImage - will be drawn below the not touched area if point was not moved

<img width="344" alt="image" src="https://github.com/user-attachments/assets/9b4e0b83-ada5-4505-b351-b7e43a2d17ba">
