### PR TITLE
iOS: Improve entity movement handling to restrict position within bounds

### DIFF
--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1231,8 +1231,12 @@
 
     if (self.selectedEntity) {
         if (state != UIGestureRecognizerStateCancelled) {
-            [self.selectedEntity moveEntityTo:[sender translationInView:self.selectedEntity]];
-            [sender setTranslation:CGPointZero inView:sender.view];
+            CGPoint translation = [sender translationInView:self];
+            CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
+            newCenter.x = MAX(0, MIN(newCenter.x, self.bounds.size.width));
+            newCenter.y = MAX(0, MIN(newCenter.y, self.bounds.size.height));
+            self.selectedEntity.center = newCenter;
+            [sender setTranslation:CGPointZero inView:self];
             [self setNeedsDisplayInRect:self.selectedEntity.bounds];
         }
 

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1232,13 +1232,18 @@
     if (self.selectedEntity) {
         if (state != UIGestureRecognizerStateCancelled) {
             CGPoint translation = [sender translationInView:self];
-            CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
-            CGFloat halfW = (self.selectedEntity.bounds.size.width * self.selectedEntity.scale) / 2.0;
-            CGFloat halfH = (self.selectedEntity.bounds.size.height * self.selectedEntity.scale) / 2.0;
-            newCenter.x = MAX(halfW, MIN(newCenter.x, self.bounds.size.width - halfW));
-            newCenter.y = MAX(halfH, MIN(newCenter.y, self.bounds.size.height - halfH));
-            self.selectedEntity.center = newCenter;
-            [sender setTranslation:CGPointZero inView:self];
+            if ([self.selectedEntity class] == [MeasurementEntity class]) {
+                [self.selectedEntity moveEntityTo:translation];
+                [sender setTranslation:CGPointZero inView:self];
+            } else {
+                CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
+                CGFloat halfW = (self.selectedEntity.bounds.size.width * self.selectedEntity.scale) / 2.0;
+                CGFloat halfH = (self.selectedEntity.bounds.size.height * self.selectedEntity.scale) / 2.0;
+                newCenter.x = MAX(halfW, MIN(newCenter.x, self.bounds.size.width - halfW));
+                newCenter.y = MAX(halfH, MIN(newCenter.y, self.bounds.size.height - halfH));
+                self.selectedEntity.center = newCenter;
+                [sender setTranslation:CGPointZero inView:self];
+            }
             [self setNeedsDisplayInRect:self.selectedEntity.bounds];
         }
 

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1233,8 +1233,8 @@
         if (state != UIGestureRecognizerStateCancelled) {
             CGPoint translation = [sender translationInView:self];
             CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
-            CGFloat halfW = self.selectedEntity.bounds.size.width / 2.0;
-            CGFloat halfH = self.selectedEntity.bounds.size.height / 2.0;
+            CGFloat halfW = self.selectedEntity.frame.size.width / 2.0;
+            CGFloat halfH = self.selectedEntity.frame.size.height / 2.0;
             newCenter.x = MAX(halfW, MIN(newCenter.x, self.bounds.size.width - halfW));
             newCenter.y = MAX(halfH, MIN(newCenter.y, self.bounds.size.height - halfH));
             self.selectedEntity.center = newCenter;

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1233,8 +1233,10 @@
         if (state != UIGestureRecognizerStateCancelled) {
             CGPoint translation = [sender translationInView:self];
             CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
-            newCenter.x = MAX(0, MIN(newCenter.x, self.bounds.size.width));
-            newCenter.y = MAX(0, MIN(newCenter.y, self.bounds.size.height));
+            CGFloat halfW = self.selectedEntity.bounds.size.width / 2.0;
+            CGFloat halfH = self.selectedEntity.bounds.size.height / 2.0;
+            newCenter.x = MAX(halfW, MIN(newCenter.x, self.bounds.size.width - halfW));
+            newCenter.y = MAX(halfH, MIN(newCenter.y, self.bounds.size.height - halfH));
             self.selectedEntity.center = newCenter;
             [sender setTranslation:CGPointZero inView:self];
             [self setNeedsDisplayInRect:self.selectedEntity.bounds];

--- a/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
+++ b/ios/RNImageEditor/RNImageEditor/RNImageEditor.m
@@ -1233,8 +1233,8 @@
         if (state != UIGestureRecognizerStateCancelled) {
             CGPoint translation = [sender translationInView:self];
             CGPoint newCenter = CGPointMake(self.selectedEntity.center.x + translation.x, self.selectedEntity.center.y + translation.y);
-            CGFloat halfW = self.selectedEntity.frame.size.width / 2.0;
-            CGFloat halfH = self.selectedEntity.frame.size.height / 2.0;
+            CGFloat halfW = (self.selectedEntity.bounds.size.width * self.selectedEntity.scale) / 2.0;
+            CGFloat halfH = (self.selectedEntity.bounds.size.height * self.selectedEntity.scale) / 2.0;
             newCenter.x = MAX(halfW, MIN(newCenter.x, self.bounds.size.width - halfW));
             newCenter.y = MAX(halfH, MIN(newCenter.y, self.bounds.size.height - halfH));
             self.selectedEntity.center = newCenter;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "type": "git",
         "url": "https://github.com/hoverinc/react-native-sketch-image"
     },
-    "version": "0.8.50",
+    "version": "0.8.51",
     "description": "react-native-sketch-canvas allows you to draw / sketch on both iOS and Android devices and sync the drawing data between users. Of course you can save as image.",
     "author": "Terry Lin, Thomas Steinbrüchel",
     "main": "index.js",


### PR DESCRIPTION
The PR restricts text dragging to canvas, so that the user cannot drag beyond the image bounds.